### PR TITLE
ユーザー一覧、ユーザー詳細コンポーネント実装とAPIの繋ぎこみ（ただし要修正）

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\User;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        return User::all();
+    }
+    public function show(User $user) // 「モデル結合ルート」を利用して簡潔に記述するため、showメソッドの引数は$idではなくUser $userとします。
+    {
+        return $user;
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -10,6 +10,9 @@ import DiseaseArticleListComponent from "./components/DiseaseArticleListComponen
 import DiseaseArticleShowComponent from "./components/DiseaseArticleShowComponent";
 import DiseaseArticleCreateComponent from "./components/DiseaseArticleCreateComponent";
 import DiseaseArticleEditComponent from "./components/DiseaseArticleEditComponent";
+import UserListComponent from "./components/UserListComponent";
+import UserShowComponent from "./components/UserShowComponent";
+import MyPageComponent from "./components/MyPageComponent";
 require('./bootstrap');
 
 window.Vue = require('vue');
@@ -36,6 +39,23 @@ const router = new VueRouter({
             name: 'disease.article.list',
             // コンポーネント名
             component: DiseaseArticleListComponent
+        },
+        {
+            path: '/users',
+            name: 'user.list',
+            component: UserListComponent
+        },
+        {
+            path: '/users/:userId',
+            name: 'user.show',
+            component: UserShowComponent,
+            props: true
+        },
+        {
+            path: '/mypage/:myId',
+            name: 'mypage',
+            component: MyPageComponent,
+            props: true
         },
         {
             path: '/diseaseArticles/:diseaseArticleId',

--- a/resources/js/components/DiseaseArticleListComponent.vue
+++ b/resources/js/components/DiseaseArticleListComponent.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="container">
         <h3 class="title">希少疾患一覧</h3>
+        <router-link v-bind:to="{name: 'disease.article.create'}">
+        <button class="btn btn-success">希少疾患に関する新規記事を投稿する</button>
+        </router-link>
             <table class="table table-hover">
                 <thead class="thead-light">
                 <tr>
@@ -48,6 +51,7 @@
         methods: {
             getDiseaseArticleLists() {
                 axios.get('/api/diseaseArticles')
+                // axios.get('/api/users')
                     .then((res) => {
                         this.diseaseArticleLists = res.data;
                     });

--- a/resources/js/components/MyPageComponent.vue
+++ b/resources/js/components/MyPageComponent.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="container">
+      <h3 class="title">マイページ</h3>
+          <div class="row justify-content-center">
+              <div class="col-sm-6">
+              </div>
+          </div>
+  </div>
+</template>

--- a/resources/js/components/UserListComponent.vue
+++ b/resources/js/components/UserListComponent.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="container">
+      <h3 class="title">ユーザー一覧</h3>
+          <table class="table table-hover">
+              <thead class="thead-light">
+              <tr>
+                  <th scope="col">#</th>
+                  <th scope="col">ユーザー名</th>
+                  <th scope="col">ユーザー詳細</th>
+              </tr>
+              </thead>
+              <tbody>
+                  <tr v-for="(list, index) in userLists" :key="index">
+                      <th scope="row">{{ list.id }}</th>
+                      <td>{{ list.name }}</td>
+                      <td>
+                          <router-link v-bind:to="{name: 'user.show', params: {userId: list.id }}">
+                              <button class="btn btn-primary">ユーザー詳細</button>
+                          </router-link>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+  </div>
+</template>
+
+<script>
+  export default {
+      data: function () {
+          return {
+              userLists: []
+          }
+      },
+      methods: {
+          getUserLists() {
+            axios.get('http://localhost:8000/api/users')
+                  .then((res) => {
+                      this.userLists = res.data;
+                  })
+                  .catch((error) => {
+                  console.log(error)
+                  })
+          }
+      },
+      mounted() {
+          this.getUserLists();
+      }
+  }
+</script>

--- a/resources/js/components/UserShowComponent.vue
+++ b/resources/js/components/UserShowComponent.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="container">
+      <h3 class="title">詳細</h3>
+          <div class="row justify-content-center">
+              <div class="col-sm-6">
+                  <form>
+                      <div class="form-group row border-bottom">
+                          <label for="user-id" class="col-sm-3 col-form-label">ID</label>
+                          <input type="text" class="col-sm-9 form-control-plaintext" readonly id="user-id" v-model="userShow.id">
+                      </div>
+                      <div class="form-group row border-bottom">
+                          <label for="user-name" class="col-sm-3 col-form-label">ユーザー名</label>
+                          <input type="text" class="col-sm-9 form-control-plaintext" readonly id="user-name" v-model="userShow.name">
+                      </div>
+                      <div class="form-group row border-bottom">
+                          <label for="profile" class="col-sm-3 col-form-label">プロフィール</label>
+                          <input type="text" class="col-sm-9 form-control-plaintext" readonly id="prifile" value="prifile">
+                      </div>
+                  </form>
+              </div>
+          </div>
+  </div>
+</template>
+
+<script>
+    export default {
+      props: {
+      // propsで親コンポーネント（app.js）から受け取ってきたuserId。value="userId"とすることで初期表示に使用できる。
+      userId: {
+      type: Number
+      }
+      },
+      data: function () {
+          return {
+              userShow: {}
+          }
+      },
+      methods: {
+          getUserShow() {
+              axios.get('/api/users/' + this.userId)
+                  .then((res) => {
+                      this.userShow = res.data;
+                  });
+          }
+      },
+      mounted() {
+          this.getUserShow();
+      }
+    }
+</script>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -14,8 +14,6 @@
                         </div>
                     @endif
                     <p>ああああ</p>
-                    <header-component></header-component>
-                    <router-view></router-view>
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -35,16 +35,19 @@
                         @guest
                             @if (Route::has('login'))
                                 <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('login') }}">{{ __('Login') }}</a>
+                                    <a class="nav-link" href="{{ route('login') }}">{{ __('ログイン') }}</a>
                                 </li>
                             @endif
 
                             @if (Route::has('register'))
                                 <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('register') }}">{{ __('Register') }}</a>
+                                    <a class="nav-link" href="{{ route('register') }}">{{ __('会員登録') }}</a>
                                 </li>
                             @endif
                         @else
+                        <li class="nav-item">
+                            <a class="nav-link" href="#">{{ __('マイページ') }}</a>
+                        </li>
                             <li class="nav-item dropdown">
                                 <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                     {{ Auth::user()->name }}
@@ -54,7 +57,7 @@
                                     <a class="dropdown-item" href="{{ route('logout') }}"
                                        onclick="event.preventDefault();
                                                      document.getElementById('logout-form').submit();">
-                                        {{ __('Logout') }}
+                                        {{ __('ログアウト') }}
                                     </a>
 
                                     <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\DiseaseArticleController;
+use App\Http\Controllers\UserController;
 
 /*
 |--------------------------------------------------------------------------
@@ -22,3 +24,5 @@ Route::get('/diseaseArticles/{diseaseArticle}', 'App\Http\Controllers\DiseaseArt
 Route::post('/diseaseArticles', 'App\Http\Controllers\DiseaseArticleController@store');
 Route::put('/diseaseArticles/{diseaseArticle}', 'App\Http\Controllers\DiseaseArticleController@update');
 Route::delete('/diseaseArticles/{diseaseArticle}', 'App\Http\Controllers\DiseaseArticleController@destroy');
+Route::get('/users', 'App\Http\Controllers\UserController@index');
+Route::get('/users/{user}', 'App\Http\Controllers\UserController@show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,9 @@
 
 use Illuminate\Support\Facades\Route;
 
+//追記
+use App\Http\Controllers\UserController;
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -12,6 +15,10 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
+
+Route::prefix('api')->group(function () {
+    Route::get('/users', [UserController::class, 'index']);
+});
 
 Route::get('/', function() {
     return view('layouts/app');


### PR DESCRIPTION
- http://localhost:8000/users/　にアクセスしても404 NOT FOUND エラーとなる。
- http://localhost:8000/api/users/　にアクセスした場合は正しくjsonが返ってきている。
- 同様の方法でDiseaseArticle（記事一覧）の繋ぎこみには成功している。
- おそらくUserListComponent.vueの以下のAPI繋ぎこみの部分がうまくいっていない模様。

```
getUserLists() {
            axios.get('http://localhost:8000/api/users')
                  .then((res) => {
                      this.userLists = res.data; // ここで取得できていない
            　　})
                  .catch((error) => {
                  console.log(error)
            　　})
}
```

Laravelのapi.phpで書いたルーティングが機能していないのかと疑い、web.phpにapi.phpと同様のルーティングを追記したがそれもうまくいかず。
原因不明。
![スクリーンショット 2022-09-19 22 01 05](https://user-images.githubusercontent.com/77926245/191023664-81962d6a-4cbe-4b8d-b62a-92c64a3914de.png)
![スクリーンショット 2022-09-19 22 01 50](https://user-images.githubusercontent.com/77926245/191023740-3c4b773d-4efa-4222-b001-5d84d47a9538.png)


